### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -673,7 +673,7 @@ ecmachine:/ guest$ (define (search dir name)
 ecmachine:/ guest$ (search '/ 'mapreduce.lsp)
 /startup/mapreduce.lsp
 ecmachine:/ guest$ (search 'apps 'mapreduce.lsp)
-#f
+# f
 ```
 
 What if we want to find all filenames that _contain_ a certain string, rather than just exact matches? We can write a `contains` function for strings using JavaScript's `String.indexOf()` method:


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
